### PR TITLE
cmd: Check if the STDIN is empty before reading

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,14 @@ func preRunFile(cmd *cobra.Command, args []string) error {
 			file, err = ioutil.ReadFile(path)
 		}
 	} else {
+		fi, err := os.Stdin.Stat()
+		if err != nil {
+			return err
+		}
+
+		if fi.Mode()&os.ModeNamedPipe == 0 {
+			return errors.New("empty STDIN")
+		}
 		file, err = ioutil.ReadAll(os.Stdin)
 	}
 


### PR DESCRIPTION
It was leaving the cmd hanging if the STDIN was empty until the user exited it