### PR TITLE
generate/hcl: Fix an error with the generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   ([Issue #13](https://github.com/cycloidio/inframap/issues/13))
 - Google graph generation from TFState
   ([Issue #7](https://github.com/cycloidio/inframap/issues/7))
+- Google graph generation from HCL
+  ([Issue #27](https://github.com/cycloidio/inframap/issues/27))
+### Fixed
+
+- HCL generation errors
+  ([Issue #29](https://github.com/cycloidio/inframap/issues/29))
 
 ## [0.1.1] _2020-07-16_
 

--- a/generate/hcl_test.go
+++ b/generate/hcl_test.go
@@ -91,6 +91,38 @@ func TestFromHCL_FlexibleEngine(t *testing.T) {
 	})
 }
 
+func TestFromHCL_Google(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		fs := afero.NewOsFs()
+
+		g, err := generate.FromHCL(fs, "./testdata/google_hcl.tf", generate.Options{Clean: true, Connections: true})
+		require.NoError(t, err)
+		require.NotNil(t, g)
+
+		eg := &graph.Graph{
+			Nodes: []*graph.Node{
+				&graph.Node{
+					Canonical: "google_compute_instance.inframap-tmp-two",
+				},
+				&graph.Node{
+					Canonical: "google_compute_instance.inframap-tmp",
+				},
+			},
+			Edges: []*graph.Edge{
+				&graph.Edge{
+					Target: "google_compute_instance.inframap-tmp",
+					Source: "google_compute_instance.inframap-tmp-two",
+					Canonicals: []string{
+						"google_compute_firewall.allow-ssh",
+					},
+				},
+			},
+		}
+
+		assertEqualGraph(t, eg, g, nil)
+	})
+}
+
 func TestFromHCL_Module(t *testing.T) {
 	t.Run("SuccessSG", func(t *testing.T) {
 		fs := afero.NewOsFs()

--- a/generate/state.go
+++ b/generate/state.go
@@ -569,6 +569,10 @@ func preprocess(g *graph.Graph, cfg map[string]map[string]interface{}, opt Optio
 				Target: edge[1],
 			})
 			if err != nil {
+				// If the edge already exists we can ignore it
+				if errors.Is(err, errcode.ErrGraphAlreadyExistsEdge) {
+					continue
+				}
 				return fmt.Errorf("could not add edge: %w", err)
 			}
 		}

--- a/generate/testdata/google_hcl.tf
+++ b/generate/testdata/google_hcl.tf
@@ -1,0 +1,88 @@
+resource "google_compute_instance" "inframap-tmp" {
+  name         = "inframap-tmp"
+  machine_type = "f1-micro"
+  zone         = "us-east1-b"
+
+  tags = ["front", "ssh"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  scheduling {
+    preemptible       = true
+    automatic_restart = false
+  }
+
+  network_interface {
+    network = google_compute_network.vpc_network.name
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+}
+
+resource "google_compute_instance" "inframap-tmp-two" {
+  name         = "inframap-tmp-two"
+  machine_type = "f1-micro"
+  zone         = "us-east1-b"
+
+  tags = ["ssh"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  scheduling {
+    preemptible       = true
+    automatic_restart = false
+  }
+
+  network_interface {
+    network = google_compute_network.vpc_network.name
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+}
+
+resource "google_compute_network" "vpc_network" {
+  name                    = "inframap-network-tmp"
+  auto_create_subnetworks = true
+}
+
+resource "google_compute_firewall" "allow-http" {
+  network     = google_compute_network.vpc_network.name
+  description = "allow incoming http traffic"
+  name        = "allow-http"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+  direction     = "INGRESS"
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["front"]
+}
+
+resource "google_compute_firewall" "allow-ssh" {
+  network     = google_compute_network.vpc_network.name
+  description = "allow SSH between instances"
+  name        = "allow-ssh"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  direction   = "INGRESS"
+  source_tags = ["ssh"]
+  target_tags = ["front"]
+}

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cycloidio/tfdocs v0.0.0-20200724124628-2ba5ed06ceae h1:IDLXCtK5MtWfBeTaKpQObzyVVLLdvqrLhCH4HFL8p1M=
-github.com/cycloidio/tfdocs v0.0.0-20200724124628-2ba5ed06ceae/go.mod h1:FKvkOvkwOg6hl3uyCnNbLiANc6BMD/ljQAU8Nf8/X8E=
 github.com/cycloidio/tfdocs v0.0.0-20200724160511-6cb97df01bd9 h1:CJKM67xbPyUorxyu0lg+EKTKnZAd3jW51JaqzT0BJlM=
 github.com/cycloidio/tfdocs v0.0.0-20200724160511-6cb97df01bd9/go.mod h1:FKvkOvkwOg6hl3uyCnNbLiANc6BMD/ljQAU8Nf8/X8E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Due to only using the 'Variables' interpolation, some Providers where failing on generating HCL
as they also needed some config values that are not present as interpolations on the config/hcl.

With this change we also append to the config all the values to have a more precises config

Closes #29, closes https://github.com/cycloidio/inframap/issues/27