### PR TITLE
Fixed: Generation error when multiple Edges hanging (not merged)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Google graph generation from HCL
   ([PR #34](https://github.com/cycloidio/inframap/pull/34))
+- Generation error when multiple Edges hanging (not merged)
+  ([PR #33](https://github.com/cycloidio/inframap/pull/33))
 
 ## [0.2.0] _2020-07-27_
 
@@ -17,6 +19,7 @@
   ([Issue #7](https://github.com/cycloidio/inframap/issues/7))
 - Google graph generation from HCL
   ([Issue #27](https://github.com/cycloidio/inframap/issues/27))
+
 ### Fixed
 
 - HCL generation errors

--- a/generate/connection.go
+++ b/generate/connection.go
@@ -64,18 +64,34 @@ func findEdgeConnections(g *graph.Graph, n *graph.Node, visited map[string]struc
 			})
 		} else {
 
+			// We make a copy of the visited so
+			// each nested edge does not share the
+			// same copy of it and produces a wrong
+			// result
+			aux := make(map[string]struct{})
+			for k, v := range visited {
+				aux[k] = v
+			}
+
 			// We get all the shortest path to a Node and append it
-			cons, err := getShortestNodePath(g, en, visited, opt)
+			cons, err := getShortestNodePath(g, en, aux, opt)
 			if err != nil {
 				return nil, err
 			}
-			con := []*connection{
-				&connection{
-					Node:      en,
-					Direction: direc,
-				},
+			// If there are no connections means it's an end Node,
+			// and as it is not a Node (it'll have entered the previous
+			// condition) it means it has no Node at the end so we do not
+			// return it
+			if len(cons) != 0 {
+				con := []*connection{
+					&connection{
+						Node:      en,
+						Direction: direc,
+					},
+				}
+
+				res = append(res, append(con, cons...))
 			}
-			res = append(res, append(con, cons...))
 		}
 	}
 	return res, nil

--- a/generate/state.go
+++ b/generate/state.go
@@ -206,6 +206,27 @@ func cleanHangingEdges(g *graph.Graph, opt Options) error {
 			}
 		}
 	}
+
+	// Now that all the hanging Edges have been cleaned
+	// we'll remove all the other Edges present if those
+	// are not meant to be displayed
+	if opt.Connections {
+	RESTART:
+		for _, n := range g.Nodes {
+			pv, rs, err := getProviderAndResource(n.Canonical, opt)
+			if err != nil {
+				return err
+			}
+			if pv.IsEdge(rs) {
+				if err := g.RemoveNodeByID(n.ID); err != nil {
+					return err
+				}
+				// We restart the loop because this operations potentially
+				// change the g.Nodes order/items
+				goto RESTART
+			}
+		}
+	}
 	return nil
 }
 

--- a/generate/testdata/aws_state_multiple_hanging_edges.json
+++ b/generate/testdata/aws_state_multiple_hanging_edges.json
@@ -1,0 +1,314 @@
+{
+    "version": 4,
+    "terraform_version": "0.12.28",
+    "serial": 1,
+    "lineage": "78acec0c-c5f3-6eec-e689-d18221d89128",
+    "outputs": {},
+    "resources": [
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_ecs_cluster",
+            "name": "ecs-cluster",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "c737f2bf-9ef5-46b3-abd1-419539a9501b"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_ecs_service",
+            "name": "wordpress",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "fc7ed1fc-fd44-4dc6-8dd4-a6b478807ba9"
+                    },
+                    "depends_on": [
+                        "aws_ecs_cluster.ecs-cluster",
+                        "aws_ecs_task_definition.wordpress",
+                        "aws_lb_listener.lb-listener",
+                        "aws_lb_target_group.lb-target-group",
+                        "aws_security_group.ecs_service"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_lb",
+            "name": "load-balancer",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 0,
+                    "attributes_flat": {
+                        "id": "1c827203-82fc-415a-ae40-618de9b57419"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_aws_lb_load-balancer",
+                        "aws_security_group.generated_sg_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group",
+            "name": "ecs_service",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 1,
+                    "attributes_flat": {
+                        "egress.#": "0",
+                        "id": "sg-0547bedace3d64924",
+                        "ingress.#": "0"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group",
+            "name": "generated_aws_lb_load-balancer",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 1,
+                    "attributes_flat": {
+                        "egress.#": "0",
+                        "id": "sg-0a769840ace64c705",
+                        "ingress.#": "0"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group",
+            "name": "generated_sg_aws_instance_front",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 1,
+                    "attributes_flat": {
+                        "egress.#": "0",
+                        "id": "sg-0d165047dfbecf4bb",
+                        "ingress.#": "0"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group",
+            "name": "generated_sg_aws_lb_load-balancer",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 1,
+                    "attributes_flat": {
+                        "egress.#": "0",
+                        "id": "sg-0313f3d256f13f50b",
+                        "ingress.#": "0"
+                    }
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "allow-alb",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-470343321",
+                        "security_group_id": "sg-0547bedace3d64924",
+                        "source_security_group_id": "sg-0a769840ace64c705"
+                    },
+                    "depends_on": [
+                        "aws_security_group.ecs_service",
+                        "aws_security_group.generated_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "internet-output",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-29718534",
+                        "security_group_id": "sg-0547bedace3d64924"
+                    },
+                    "depends_on": [
+                        "aws_security_group.ecs_service"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "load-balancer_public_from_the_internet_http",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-626462736",
+                        "security_group_id": "sg-0a769840ace64c705"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "load-balancer_public_from_the_internet_https",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-4048962960",
+                        "security_group_id": "sg-0a769840ace64c705"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "output",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-3253196881",
+                        "security_group_id": "sg-0a769840ace64c705"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "rule_egress_generated_nTiRTlKCl",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-2270803082",
+                        "security_group_id": "sg-0d165047dfbecf4bb",
+                        "source_security_group_id": "sg-0313f3d256f13f50b"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_sg_aws_instance_front",
+                        "aws_security_group.generated_sg_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "rule_egress_generated_sg_aws_instance_front_to_generated_sg_aws_lb_load-balancer_80_80",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-3178401203",
+                        "security_group_id": "sg-0d165047dfbecf4bb",
+                        "source_security_group_id": "sg-0313f3d256f13f50b"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_sg_aws_instance_front",
+                        "aws_security_group.generated_sg_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "rule_ingress_generated_nTiRTlKCl",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-2395627403",
+                        "security_group_id": "sg-0313f3d256f13f50b",
+                        "source_security_group_id": "sg-0d165047dfbecf4bb"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_sg_aws_instance_front",
+                        "aws_security_group.generated_sg_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        },
+        {
+            "module": "module.tf-8-wordpress-demo",
+            "mode": "managed",
+            "type": "aws_security_group_rule",
+            "name": "rule_ingress_generated_sg_aws_instance_front_to_generated_sg_aws_lb_load-balancer_80_80",
+            "provider": "module.tf-8-wordpress-demo.provider.aws",
+            "instances": [
+                {
+                    "schema_version": 2,
+                    "attributes_flat": {
+                        "id": "sgrule-1651011552",
+                        "security_group_id": "sg-0313f3d256f13f50b",
+                        "source_security_group_id": "sg-0d165047dfbecf4bb"
+                    },
+                    "depends_on": [
+                        "aws_security_group.generated_sg_aws_instance_front",
+                        "aws_security_group.generated_sg_aws_lb_load-balancer"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -58,6 +58,105 @@ func TestAddNode(t *testing.T) {
 	})
 }
 
+func TestRemoveNodeByID(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		g := graph.New()
+		n1 := &graph.Node{ID: "1", Canonical: "can1"}
+		n2 := &graph.Node{ID: "2", Canonical: "2"}
+
+		err := g.AddNode(n1)
+		require.NoError(t, err)
+
+		err = g.AddNode(n2)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*graph.Node{n1, n2}, g.Nodes)
+
+		err = g.RemoveNodeByID(n1.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*graph.Node{n2}, g.Nodes)
+
+		err = g.RemoveNodeByID(n2.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*graph.Node{}, g.Nodes)
+	})
+	t.Run("SuccessWithEdges", func(t *testing.T) {
+		g := graph.New()
+		n1 := &graph.Node{ID: "1", Canonical: "can1"}
+		n2 := &graph.Node{ID: "2", Canonical: "can2"}
+		e := &graph.Edge{ID: "1", Source: n1.ID, Target: n2.ID}
+
+		err := g.AddNode(n1)
+		require.NoError(t, err)
+
+		err = g.AddNode(n2)
+		require.NoError(t, err)
+
+		err = g.AddEdge(e)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*graph.Edge{e}, g.Edges)
+
+		err = g.RemoveNodeByID(n1.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*graph.Node{n2}, g.Nodes)
+		assert.Equal(t, []*graph.Edge{}, g.Edges)
+	})
+	t.Run("SuccessWithEdges", func(t *testing.T) {
+		g := graph.New()
+		n1 := &graph.Node{ID: "1", Canonical: "can1"}
+		n2 := &graph.Node{ID: "2", Canonical: "can2"}
+		n3 := &graph.Node{ID: "3", Canonical: "can3"}
+		n4 := &graph.Node{ID: "4", Canonical: "can4"}
+		e1 := &graph.Edge{ID: "1", Source: n1.ID, Target: n2.ID}
+		e2 := &graph.Edge{ID: "2", Source: n2.ID, Target: n3.ID}
+		e3 := &graph.Edge{ID: "3", Source: n1.ID, Target: n4.ID}
+
+		err := g.AddNode(n1)
+		require.NoError(t, err)
+
+		err = g.AddNode(n2)
+		require.NoError(t, err)
+
+		err = g.AddNode(n3)
+		require.NoError(t, err)
+
+		err = g.AddNode(n4)
+		require.NoError(t, err)
+
+		err = g.AddEdge(e1)
+		require.NoError(t, err)
+
+		err = g.AddEdge(e2)
+		require.NoError(t, err)
+
+		err = g.AddEdge(e3)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*graph.Node{n1, n2, n3, n4}, g.Nodes)
+		assert.Equal(t, []*graph.Edge{e1, e2, e3}, g.Edges)
+
+		err = g.RemoveNodeByID(n2.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, []*graph.Node{n1, n3, n4}, g.Nodes)
+		assert.Equal(t, []*graph.Edge{e3}, g.Edges)
+	})
+	t.Run("ErrGraphNotFoundNode", func(t *testing.T) {
+		g := graph.New()
+		n1 := &graph.Node{ID: "1", Canonical: "can1"}
+
+		err := g.AddNode(n1)
+		require.NoError(t, err)
+
+		err = g.RemoveNodeByID("invalid-id")
+		assert.Error(t, err, errcode.ErrGraphNotFoundNode.Error())
+	})
+}
+
 func TestAddEdge(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		g := graph.New()

--- a/printer/dot/printer.go
+++ b/printer/dot/printer.go
@@ -91,8 +91,16 @@ func (d Dot) Print(g *graph.Graph, opt printer.Options, w io.Writer) error {
 	}
 
 	for _, e := range g.Edges {
-		src, _ := g.GetNodeByID(e.Source)
-		tr, _ := g.GetNodeByID(e.Target)
+		src, err := g.GetNodeByID(e.Source)
+		if err != nil {
+			return err
+		}
+
+		tr, err := g.GetNodeByID(e.Target)
+		if err != nil {
+			return err
+		}
+
 		graph.AddEdge(fmt.Sprintf("%q", src.Canonical), fmt.Sprintf("%q", tr.Canonical), true, nil)
 	}
 


### PR DESCRIPTION
When multiple Edges Hanging we had an issue that they where left alone.

Also for big graphs with nested connections we where having an issue to calculate the shortest path to the next Node (`visited` was shared between different paths so it was incorrect).