### PR TITLE
Fixed: Google graph generation from HCL 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Google graph generation from HCL
+  ([PR #34](https://github.com/cycloidio/inframap/pull/34))
+
 ## [0.2.0] _2020-07-27_
 
 ### Added

--- a/generate/hcl.go
+++ b/generate/hcl.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cycloidio/inframap/errcode"
 	"github.com/cycloidio/inframap/graph"
+	"github.com/cycloidio/inframap/provider"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -99,6 +100,7 @@ func FromHCL(fs afero.Fs, path string, opt Options) (*graph.Graph, error) {
 		if ok {
 			links = getBodyLinks(body)
 			cfg := getBodyJSON(body)
+			cfg[provider.HCLCanonicalKey] = rk
 			resourcesRawConfig[n.ID] = cfg
 		} else {
 			// If it's not a hclsyntax.Body normally

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -95,9 +95,27 @@ func (a Provider) ResourceInOut(id, rs string, cfgs map[string]map[string]interf
 			// is it connected and not itself
 			continue
 		}
-		pvid, ok := cfg["id"].(string)
+		ipvid, ok := cfg["id"]
 		if !ok {
-			// If for some reason it's not an String we continue
+			// If the 'id' is not defined then it is HCL and
+			// the HCLCanonicalKey should be present
+			ipvid, ok = cfg[provider.HCLCanonicalKey]
+			if !ok {
+				// If it is also not present
+				// we can ignore it as we cannot
+				// reference it
+				continue
+			}
+			// We need to fake it as a '${}' because that is
+			// how it is expected from the caller
+			// The .something is not important
+			ipvid = fmt.Sprintf("${%s.something}", ipvid)
+		}
+
+		pvid, ok := ipvid.(string)
+		if !ok {
+			// If the ID is not an string
+			// we continue
 			continue
 		}
 		for _, in := range tagins {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -4,6 +4,11 @@ import (
 	"github.com/cycloidio/tfdocs/resource"
 )
 
+// HCLCanonicalKey is used to define a specific key to the config, in this case
+// the HCL config, as it does not have an 'id' we'll add this key with the
+// Canonical of the Resource (ex: _im_canonical => aws_lb.front)
+const HCLCanonicalKey = "_im_canonical"
+
 // Provider is an interface to abstract common functions on all the
 // providers
 type Provider interface {


### PR DESCRIPTION
On Google we where not able to identify, on HCL, which was the resource that was In or Out, as we where using the ID ad on the HCL there are no IDs.

We have added a `provider.HCLCanonicalKey` that will be set on the HCL config so we are able to get the resource identifier of that specific config.