### PR TITLE
dot: increase padding between the image and the label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   ([PR #34](https://github.com/cycloidio/inframap/pull/34))
 - Generation error when multiple Edges hanging (not merged)
   ([PR #33](https://github.com/cycloidio/inframap/pull/33))
+- Padding between the image and the label for the `dot` printer
+  ([PR #42](https://github.com/cycloidio/inframap/pull/42))
 
 ## [0.2.0] _2020-07-27_
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/adrg/xdg v0.2.1
-	github.com/awalterschulze/gographviz v2.0.1+incompatible
+	github.com/awalterschulze/gographviz v2.0.2-0.20200810082452-794ba2878b95+incompatible
 	github.com/chr4/pwgen v1.1.0
 	github.com/cycloidio/tfdocs v0.0.0-20200724160511-6cb97df01bd9
 	github.com/dmarkham/enumer v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/awalterschulze/gographviz v2.0.1+incompatible h1:XIECBRq9VPEQqkQL5pw2OtjCAdrtIgFKoJU8eT98AS8=
-github.com/awalterschulze/gographviz v2.0.1+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
+github.com/awalterschulze/gographviz v2.0.2-0.20200810082452-794ba2878b95+incompatible h1:hrDT3rqJ08ZrWfasmCtof4lphIpuh0a8F6AQ24fPtE8=
+github.com/awalterschulze/gographviz v2.0.2-0.20200810082452-794ba2878b95+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.12 h1:KrjyosZvkpJjcwMk0RNxMZewQ47v7+ZkbQDXjWsJMs8=

--- a/printer/dot/printer.go
+++ b/printer/dot/printer.go
@@ -59,6 +59,7 @@ func (d Dot) Print(g *graph.Graph, opt printer.Options, w io.Writer) error {
 			attr["shape"] = "plaintext"
 			attr["labelloc"] = "b"
 			attr["height"] = "1.15"
+			attr["imagepos"] = "tc"
 
 			// If the file does not exists on the Cache path, we have to write it,
 			// if not it means it's already correct so nothing to be done


### PR DESCRIPTION
we increase the padding by setting the attribute `imagePos` to `tc` value (`Top Centered`). [[doc](https://graphviz.org/doc/info/attrs.html#d:imagepos)]

![graphs](https://pastefile-owl.cycloid.io/dc1457cca8270e46133228b4a59c0985)

Left: without `imagePos`
Right: with `imagePos`