### PR TITLE
generate: Add support for multiple modules having same resource names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Terraform version from 0.14.6 to 0.14.7
   ([PR #107](https://github.com/cycloidio/inframap/pull/107))
 
+### Fixed
+
+- Multiple modules with same resource name now work correctly using full module name `module.NAME.aws_insatance.NAME2`
+  ([Issue #103](https://github.com/cycloidio/inframap/issues/103))
+
 ## [0.5.2] _2021-02-09_
 
 ### Changed

--- a/generate/state.go
+++ b/generate/state.go
@@ -56,8 +56,28 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 		}
 	}
 
-	for _, v := range file.State.Modules {
-		for rk, rv := range v.Resources {
+	// moduleMode means that there are more than 1 module on the TFState
+	// so that we have to prefix resources with the module name
+	// or repetition of canonicals would be possible.
+	// firstModule is a holder to see if we have more than 1 module with
+	// resources inside
+	// We have to do it this way because there is always a "" module so if
+	// there is 1 it'll actually be 2, this way we check if they have something
+	// inside before setting the moduleMode
+	moduleMode := false
+	firstModule := false
+	for _, m := range file.State.Modules {
+		if len(m.Resources) > 0 {
+			if firstModule {
+				moduleMode = true
+				break
+			}
+			firstModule = true
+		}
+	}
+
+	for _, m := range file.State.Modules {
+		for rk, rv := range m.Resources {
 			// If it's not a Resource we ignore it
 			if rv.Addr.Resource.Mode != addrs.ManagedResourceMode {
 				continue
@@ -87,6 +107,12 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 					deps = append(deps, instanceCurrentDependenciesToString(iv.Current.Dependencies)...)
 				}
 
+				// Dependencies will have reference to inside the module
+				// so we need to prefix them if needed to find the right node
+				for i, d := range deps {
+					deps[i] = prefixWithModule(moduleMode, m.Addr.Module().String(), d)
+				}
+
 				aux := make(map[string]interface{})
 				if iv.Current.AttrsJSON != nil {
 					// For TF 0.12
@@ -109,7 +135,7 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 				}
 				n := &graph.Node{
 					ID:        uuid.NewV4().String(),
-					Canonical: rk,
+					Canonical: prefixWithModule(moduleMode, m.Addr.Module().String(), rk),
 					TFID:      aux["id"].(string),
 					Resource:  *res,
 				}
@@ -266,20 +292,23 @@ func buildConfig(g *graph.Graph, cfg map[string]map[string]interface{}, nodeCanI
 			return nil, fmt.Errorf("could not find config of node %q: %w", n.Canonical, errcode.ErrInvalidTFStateFile)
 		}
 
-		// path[0] == resource Type ex: aws_security_group
-		// path[1] == resource Name ex: front-port80
+		// Canonical = module.name.aws_security_group.front-port80
+		// rt == path[-2] == resource Type ex: module.name.aws_security_group
+		// rn == path[-1] == resource Name ex: front-port80
 		path := strings.Split(n.Canonical, ".")
+		rn := path[len(path)-1]
+		rt := strings.Join(path[:len(path)-1], ".")
 
-		if _, ok := endCfg[path[0]]; !ok {
-			endCfg[path[0]] = make(map[string]interface{})
+		if _, ok := endCfg[rt]; !ok {
+			endCfg[rt] = make(map[string]interface{})
 		}
 
-		if _, ok := endCfg[path[0]].(map[string]interface{})[path[1]]; ok {
+		if _, ok := endCfg[rt].(map[string]interface{})[rn]; ok {
 			// If we have it already set, then it's not a valid config
 			return nil, fmt.Errorf("repeated config node for %q: %w", n.Canonical, errcode.ErrInvalidTFStateFile)
 		}
 
-		endCfg[path[0]].(map[string]interface{})[path[1]] = c
+		endCfg[rt].(map[string]interface{})[rn] = c
 	}
 
 	for _, e := range g.Edges {
@@ -294,21 +323,24 @@ func buildConfig(g *graph.Graph, cfg map[string]map[string]interface{}, nodeCanI
 				return nil, fmt.Errorf("could not find config of the Node %q: %w", can, errcode.ErrInvalidTFStateFile)
 			}
 
-			// path[0] == resource Type ex: aws_security_group
-			// path[1] == resource Name ex: front-port80
+			// Canonical = module.name.aws_security_group.front-port80
+			// rt == path[-2] == resource Type ex: module.name.aws_security_group
+			// rn == path[-1] == resource Name ex: front-port80
 			path := strings.Split(can, ".")
+			rn := path[len(path)-1]
+			rt := strings.Join(path[:len(path)-1], ".")
 
-			if _, ok := endCfg[path[0]]; !ok {
-				endCfg[path[0]] = make(map[string]interface{})
+			if _, ok := endCfg[rt]; !ok {
+				endCfg[rt] = make(map[string]interface{})
 			}
 
-			if _, ok := endCfg[path[0]].(map[string]interface{})[path[1]]; ok {
+			if _, ok := endCfg[rt].(map[string]interface{})[rn]; ok {
 				// As a connection canonical can be shared between different
 				// connections this will happen so we ignore it
 				continue
 			}
 
-			endCfg[path[0]].(map[string]interface{})[path[1]] = c
+			endCfg[rt].(map[string]interface{})[rn] = c
 		}
 	}
 
@@ -606,7 +638,13 @@ func getProviderAndResource(rk string, opt Options) (provider.Provider, string, 
 
 	if opt.Raw {
 		pv = provider.RawProvider{}
-		rs = strings.Split(rk, ".")[0]
+
+		rss := strings.Split(rk, ".")
+		if len(rss) > 1 {
+			rs = rss[len(rss)-2]
+		} else {
+			rs = rk
+		}
 	} else {
 		pv, rs, err = factory.GetProviderAndResource(rk)
 	}
@@ -680,4 +718,12 @@ func preprocess(g *graph.Graph, cfg map[string]map[string]interface{}, opt Optio
 		visitedProviders[pv.Type()] = struct{}{}
 	}
 	return nil
+}
+
+// prefixWithModule will check if it has to prefix and do so if needed
+func prefixWithModule(moduleMode bool, moduleName, resource string) string {
+	if moduleMode && moduleName != "" {
+		resource = fmt.Sprintf("%s.%s", moduleName, resource)
+	}
+	return resource
 }

--- a/generate/state_test.go
+++ b/generate/state_test.go
@@ -35,13 +35,13 @@ func TestFromState_AWS(t *testing.T) {
 		eg := &graph.Graph{
 			Nodes: []*graph.Node{
 				&graph.Node{
-					Canonical: "aws_lb.tQBgz",
+					Canonical: "module.lemp.aws_lb.tQBgz",
 				},
 				&graph.Node{
-					Canonical: "aws_launch_template.vIkyE",
+					Canonical: "module.lemp.aws_launch_template.vIkyE",
 				},
 				&graph.Node{
-					Canonical: "aws_db_instance.Cpbzf",
+					Canonical: "module.lemp.aws_db_instance.Cpbzf",
 				},
 				&graph.Node{
 					Canonical: "im_out.tcp/443->443",
@@ -53,23 +53,23 @@ func TestFromState_AWS(t *testing.T) {
 			Edges: []*graph.Edge{
 				&graph.Edge{
 					Source:     "im_out.tcp/80->80",
-					Target:     "aws_lb.tQBgz",
+					Target:     "module.lemp.aws_lb.tQBgz",
 					Canonicals: []string(nil),
 				},
 				&graph.Edge{
 					Source:     "im_out.tcp/443->443",
-					Target:     "aws_lb.tQBgz",
+					Target:     "module.lemp.aws_lb.tQBgz",
 					Canonicals: []string(nil),
 				},
 				&graph.Edge{
-					Source:     "aws_lb.tQBgz",
-					Target:     "aws_launch_template.vIkyE",
-					Canonicals: []string{"aws_security_group.rZnGI", "aws_security_group.YPHPR"},
+					Source:     "module.lemp.aws_lb.tQBgz",
+					Target:     "module.lemp.aws_launch_template.vIkyE",
+					Canonicals: []string{"module.lemp.aws_security_group.rZnGI", "module.lemp.aws_security_group.YPHPR"},
 				},
 				&graph.Edge{
-					Source:     "aws_launch_template.vIkyE",
-					Target:     "aws_db_instance.Cpbzf",
-					Canonicals: []string{"aws_security_group.YPHPR", "aws_security_group.LHwFh"},
+					Source:     "module.lemp.aws_launch_template.vIkyE",
+					Target:     "module.lemp.aws_db_instance.Cpbzf",
+					Canonicals: []string{"module.lemp.aws_security_group.YPHPR", "module.lemp.aws_security_group.LHwFh"},
 				},
 			},
 		}

--- a/provider/factory/factory.go
+++ b/provider/factory/factory.go
@@ -33,7 +33,15 @@ var (
 // GetProviderAndResource returns the Interface
 // and the resource name "aws_alb.front" -> "aws_alb"
 func GetProviderAndResource(can string) (provider.Provider, string, error) {
-	rs := strings.Split(can, ".")[0]
+	// Due to modules, we'll check it from the back not from
+	// the front as it may have modules prefix
+	rss := strings.Split(can, ".")
+	var rs string
+	if len(rss) > 1 {
+		rs = rss[len(rss)-2]
+	} else {
+		rs = can
+	}
 	match := reProvider.FindStringSubmatch(rs)
 
 	if match == nil {


### PR DESCRIPTION
What we'll do is check if there are more than 1 module with resources, if so then we'll use full
resource name 'module.NAME.aws_instance.NAME2' as canonical. This will also be used on the config
output as key canonical for the resource.

If there is only 1 module they'll not be prefixed in favor of readability of the names.

Closes #103 