### PR TITLE
cmd: The flags --hcl and --tfstate are no longer required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Terraform version from 0.14.6 to 0.14.8
   ([PR #114](https://github.com/cycloidio/inframap/pull/114))
+- The flags `--hcl` and `--tfstate` are no longer required, the type will be guessed now
+  ([Issue #101](https://github.com/cycloidio/inframap/issues/101))
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ This basically builds `inframap` with the current sources.
 
 To add a new Provider you need to follow the `provider.Provider` interface and create it on the `provider/{provider_name}`, also add it to the `provider.Type` list and then run `make generate`. Basically you can also check any of the other providers that we already have.
 
-To add a new test we recommend to run the `inframap prune --canonicals --tfstate [FILE]` and add the test to the `generate/testdata/` and add a new test to the `generate/graph_test.go`
+To add a new test we recommend to run the `inframap prune --canonicals [FILE]` and add the test to the `generate/testdata/` and add a new test to the `generate/graph_test.go`
 
 #### Add a new Printer
 

--- a/README.md
+++ b/README.md
@@ -79,32 +79,36 @@ The most important subcommands are:
 Visualizing with dot
 
 ```shell
-$ inframap generate --tfstate state.tfstate | dot -Tpng > graph.png
+$ inframap generate state.tfstate | dot -Tpng > graph.png
 ```
 
 or from the terminal itself
 
 ```shell
-$ inframap generate --tfstate state.tfstate | graph-easy
+$ inframap generate state.tfstate | graph-easy
 ```
 
 or from HCL
 
 ```shell
-$ inframap generate --hcl config.tf | graph-easy
+$ inframap generate config.tf | graph-easy
 ```
 
 or HCL module
 
 ```shell
-$ inframap generate --hcl ./my-module/ | graph-easy
+$ inframap generate ./my-module/ | graph-easy
 ```
 
 using docker image (assuming that your Terraform files are in the working directory)
 
 ```shell
-$ docker run --rm -v ${PWD}:/opt cycloid/inframap generate --tfstate /opt/terraform.tfstate
+$ docker run --rm -v ${PWD}:/opt cycloid/inframap generate /opt/terraform.tfstate
 ```
+
+
+**Note:** InfraMap will guess the type of the input (HCL or TFState) by validating if it's a JSON and if it fails then we fallback
+to HCL (except if you send a directory on args, the it'll use HCL directly), to force one specific type you can use `--hcl` or `--tfstate` flags.
 
 ## How is it different to `terraform graph`
 
@@ -121,19 +125,19 @@ With `terraform graph`:
   <img src="docs/terraformgraph.svg" width="400">
 </p>
 
-With `inframap generate --hcl ./terraform/module-magento/ | dot -Tpng > inframap.png`:
+With `inframap generate ./terraform/module-magento/ | dot -Tpng > inframap.png`:
 
 <p align="center">
   <img src="docs/inframap.png" width="400">
 </p>
 
-With `inframap generate --hcl --connections=false ./terraform/module-magento/ | dot -Tpng > inframapconnections.png`:
+With `inframap generate --connections=false ./terraform/module-magento/ | dot -Tpng > inframapconnections.png`:
 
 <p align="center">
   <img src="docs/inframapconnections.png" width="400">
 </p>
 
-With `inframap generate --hcl ./terraform/module-magento/ --raw | dot -Tpng > inframapraw.png`:
+With `inframap generate ./terraform/module-magento/ --raw | dot -Tpng > inframapraw.png`:
 
 <p align="center">
   <img src="docs/inframapraw.png" width="400">
@@ -166,8 +170,8 @@ Terraform allows users to use `backends` (S3, Google Cloud Storage, Swift, etc.)
 
 | backend | command                                                                          |
 |---------|----------------------------------------------------------------------------------|
-| S3      | `aws s3 cp s3://bucket/path/to/your/file.tfstate - \| inframap generate --tfstate` |
-| GCS     | `gsutil cat gs://bucket/path/to/your/file.tfstate \| inframap generate --tfstate`  |
+| S3      | `aws s3 cp s3://bucket/path/to/your/file.tfstate - \| inframap generate` |
+| GCS     | `gsutil cat gs://bucket/path/to/your/file.tfstate \| inframap generate`  |
 
 ### What does the error `Error: error while reading TFState: state snapshot was created by Terraform v0.13.0, which is newer than current v0.12.28; upgrade to Terraform v0.13.0 or greater to work with this state` mean?
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -25,7 +25,7 @@ var (
 		Use:     "generate [FILE]",
 		Short:   "Generates the Graph",
 		Long:    "Generates the Graph from TFState or HCL",
-		Example: "inframap generate --tfstate state.tfstate",
+		Example: "inframap generate state.tfstate\ncat state.tfstate | inframap generate",
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: preRunFile,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -14,7 +14,7 @@ var (
 		Use:     "prune [FILE]",
 		Short:   "Prunes the file",
 		Long:    "Prunes the TFState or HCL file",
-		Example: "inframap prune --tfstate state.tfstate",
+		Example: "inframap prune state.tfstate",
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: preRunFile,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -26,7 +26,7 @@ var (
 
 				fmt.Println(string(s))
 			} else {
-				return errors.New("prune does not support --hcl yet")
+				return errors.New("prune does not support HCL yet")
 			}
 
 			return nil


### PR DESCRIPTION
Now we'll try to guess the input types by first using JSON parser and if it fails we fallback to HCL.

The flags are still used to be able to force one specific type. The only reason to use them
is if the user uses HCL writen in JSON which is possible