### PR TITLE
cmd: Fixed swallowed error due to scope redeclaration of 'err'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Terraform version from 0.14.9 to 0.14.10
   ([PR #128](https://github.com/cycloidio/inframap/pull/128))
 
+### Fixed
+
+- When generating code from HCL errors are now displayed properly
+  ([Issue #120](https://github.com/cycloidio/inframap/pull/120))
+
 ## [0.6.2] _2021-03-30_
 
 ### Added

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -50,7 +50,8 @@ var (
 					fs := afero.NewMemMapFs()
 					path = "module.tf"
 
-					f, err := fs.Create(path)
+					var f afero.File
+					f, err = fs.Create(path)
 					if err != nil {
 						return err
 					}

--- a/errcode/code.go
+++ b/errcode/code.go
@@ -23,8 +23,9 @@ var (
 	ErrProviderNotFoundDataSource = errors.New("provider data source not found")
 	ErrProviderNotFound           = errors.New("provider not found")
 
-	ErrInvalidTFStateFile    = errors.New("invalid Terraform State file")
-	ErrInvalidTFStateVersion = errors.New("invalid Terraform State version, we only support version 3 and 4")
+	ErrInvalidTFStateFile                  = errors.New("invalid Terraform State file")
+	ErrInvalidTFStateVersion               = errors.New("invalid Terraform State version, we only support version 3 and 4")
+	ErrInvalidTFStateFileMissingResourceID = errors.New("invalid Terraform State file, a resource is missing the attributes.id")
 
 	ErrPrinterNotFound = errors.New("printer not found")
 

--- a/generate/state.go
+++ b/generate/state.go
@@ -143,10 +143,14 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 				if err != nil {
 					return nil, nil, err
 				}
+				tfid, ok := aux["id"]
+				if !ok {
+					return nil, nil, fmt.Errorf("resource %q: %w", rk, errcode.ErrInvalidTFStateFileMissingResourceID)
+				}
 				n := &graph.Node{
 					ID:        uuid.NewV4().String(),
 					Canonical: prefixWithModule(moduleMode, m.Addr.Module().String(), rk),
-					TFID:      aux["id"].(string),
+					TFID:      tfid.(string),
 					Resource:  *res,
 				}
 

--- a/generate/state_test.go
+++ b/generate/state_test.go
@@ -2,6 +2,7 @@ package generate_test
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -28,6 +29,14 @@ func TestFromState(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, g)
 		require.NotNil(t, cfg)
+	})
+	t.Run("NoID", func(t *testing.T) {
+		src, err := ioutil.ReadFile("./testdata/error_missing_id.json")
+		require.NoError(t, err)
+
+		_, _, err = generate.FromState(src, generate.Options{Clean: true, Connections: true, ExternalNodes: true})
+		fmt.Println(err)
+		assert.True(t, errors.Is(err, errcode.ErrInvalidTFStateFileMissingResourceID))
 	})
 }
 

--- a/generate/state_test.go
+++ b/generate/state_test.go
@@ -20,6 +20,15 @@ func TestFromState(t *testing.T) {
 		_, _, err = generate.FromState(src, generate.Options{Clean: true, Connections: true, ExternalNodes: true})
 		assert.True(t, errors.Is(err, errcode.ErrInvalidTFStateVersion))
 	})
+	t.Run("Empty", func(t *testing.T) {
+		src, err := ioutil.ReadFile("./testdata/empty.json")
+		require.NoError(t, err)
+
+		g, cfg, err := generate.FromState(src, generate.Options{Clean: true, Connections: true, ExternalNodes: true})
+		require.NoError(t, err)
+		require.NotNil(t, g)
+		require.NotNil(t, cfg)
+	})
 }
 
 func TestFromState_AWS(t *testing.T) {

--- a/generate/testdata/empty.json
+++ b/generate/testdata/empty.json
@@ -1,0 +1,7 @@
+{
+    "version": 3,
+    "terraform_version": "0.11.14",
+    "serial": 83,
+    "lineage": "3fd5eb87-d6b9-8b47-6c2d-7209f7f884ee",
+    "resources": []
+}

--- a/generate/testdata/error_missing_id.json
+++ b/generate/testdata/error_missing_id.json
@@ -1,0 +1,18 @@
+{
+  "version":4,
+  "terraform_verison": "0.12.28",
+  "resources": [
+    {
+      "type":"aws_db_instance",
+      "mode":"managed",
+      "name": "mydb",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "attributes":{}
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
As it was redeclared on the same scope it was overwriting the one on the general scope with was still 'nil'
so it did not fail and continued with a 'g == nil' which caused the graph to panic

Fixes #120 