### PR TITLE
cmd: Added new flag --description-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Added
+
+- New flag `--description-file` to generate a description file of the Graph Nodes
+  ([Issue #178](https://github.com/cycloidio/inframap/issues/178))
+
 ### Changed
 
 - Updated the `tfdocs` version

--- a/generate/hcl_test.go
+++ b/generate/hcl_test.go
@@ -13,7 +13,7 @@ func TestFromHCL_AWS(t *testing.T) {
 	t.Run("SuccessSG", func(t *testing.T) {
 		fs := afero.NewOsFs()
 
-		g, err := generate.FromHCL(fs, "./testdata/aws_hcl_sg.tf", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
+		g, cfg, err := generate.FromHCL(fs, "./testdata/aws_hcl_sg.tf", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
 		require.NoError(t, err)
 		require.NotNil(t, g)
 
@@ -67,7 +67,7 @@ func TestFromHCL_AWS(t *testing.T) {
 			},
 		}
 
-		assertEqualGraph(t, eg, g, nil)
+		assertEqualGraph(t, eg, g, cfg)
 	})
 }
 
@@ -75,7 +75,7 @@ func TestFromHCL_FlexibleEngine(t *testing.T) {
 	t.Run("SuccessSG", func(t *testing.T) {
 		fs := afero.NewOsFs()
 
-		g, err := generate.FromHCL(fs, "./testdata/flexibleengine_hcl.tf", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
+		g, cfg, err := generate.FromHCL(fs, "./testdata/flexibleengine_hcl.tf", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
 		require.NoError(t, err)
 		require.NotNil(t, g)
 
@@ -103,7 +103,7 @@ func TestFromHCL_FlexibleEngine(t *testing.T) {
 			},
 		}
 
-		assertEqualGraph(t, eg, g, nil)
+		assertEqualGraph(t, eg, g, cfg)
 	})
 }
 
@@ -111,7 +111,7 @@ func TestFromHCL_Google(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		fs := afero.NewOsFs()
 
-		g, err := generate.FromHCL(fs, "./testdata/google_hcl.tf", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
+		g, cfg, err := generate.FromHCL(fs, "./testdata/google_hcl.tf", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
 		require.NoError(t, err)
 		require.NotNil(t, g)
 
@@ -135,7 +135,7 @@ func TestFromHCL_Google(t *testing.T) {
 			},
 		}
 
-		assertEqualGraph(t, eg, g, nil)
+		assertEqualGraph(t, eg, g, cfg)
 	})
 }
 
@@ -143,7 +143,7 @@ func TestFromHCL_Module(t *testing.T) {
 	t.Run("SuccessSG", func(t *testing.T) {
 		fs := afero.NewOsFs()
 
-		g, err := generate.FromHCL(fs, "./testdata/tf-module/", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
+		g, cfg, err := generate.FromHCL(fs, "./testdata/tf-module/", generate.Options{Clean: true, Connections: true, ExternalNodes: true})
 		require.NoError(t, err)
 		require.NotNil(t, g)
 
@@ -197,6 +197,6 @@ func TestFromHCL_Module(t *testing.T) {
 			},
 		}
 
-		assertEqualGraph(t, eg, g, nil)
+		assertEqualGraph(t, eg, g, cfg)
 	})
 }

--- a/generate/helper_test.go
+++ b/generate/helper_test.go
@@ -79,10 +79,8 @@ func assertEqualGraph(t *testing.T, expected, actual *graph.Graph, actualCfg map
 	// it'll be ignored if nil
 	if actualCfg != nil {
 		actualCans := make([]string, 0, 0)
-		for k, v := range actualCfg["resource"].(map[string]interface{}) {
-			for n := range v.(map[string]interface{}) {
-				actualCans = append(actualCans, fmt.Sprintf("%s.%s", k, n))
-			}
+		for k, _ := range actualCfg {
+			actualCans = append(actualCans, k)
 		}
 
 		expectedCans := make([]string, 0, 0)


### PR DESCRIPTION
Which will return a description file of the Nodes, which will contain
all the information from the read configuration.

We had to change the generate.FromHCL function to return now a new
parameter, so now it's the same as the generate.FromState.

Also the returned cofig from both of those methods has changed formats
as it's now just the resources on the first level without being them
nested inside a 'resources' and then grouped by resource type. It was
a newsense so we changed that

Closes #178 