### PR TITLE
README: Make a more precise annotation on the backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Terraform allows users to use `backends` (S3, Google Cloud Storage, Swift, etc.)
 |---------|--------------------------------------------------------------------------|
 | S3      | `aws s3 cp s3://bucket/path/to/your/file.tfstate - \| inframap generate` |
 | GCS     | `gsutil cat gs://bucket/path/to/your/file.tfstate \| inframap generate`  |
-| HTTP    | `terraform state pull \| inframap generate`                              |
+
+A general solution is also to just use `terraform state pull \| inframap generate` as it'll pull the state from whichever backend is actually stored
 
 ## License
 


### PR DESCRIPTION
As if you just use 'terraform state pull' will pull it from whichever backend you have it stored, so
it's amore general solution than using the Backend specific client to pull it from