### PR TITLE
Bundle grpahViz and use non root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - New flag `--description-file` to generate a description file of the Graph Nodes
   ([Issue #178](https://github.com/cycloidio/inframap/issues/178))
+- `graphviz` is now in the Docker image so no need of external tools to generate the graph by [@agalazis](https://github.com/agalazis)
+  ([PR #221](https://github.com/cycloidio/inframap/pull/221))
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.16.5-alpine3.12 as builder
-
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -8,9 +7,19 @@ RUN go mod download
 
 COPY . .
 
-RUN apk -q --no-progress add git make graphviz ttf-dejavu; \
-	make build
+RUN apk -q --no-progress add git make \
+	&& make build
 
 FROM alpine
-COPY --from=builder /app/inframap /app/
-ENTRYPOINT ["/app/inframap"]
+
+RUN apk -q --no-progress add graphviz ttf-dejavu\
+        && addgroup -g 1000 inframap \
+        && adduser -u 1000 -G inframap -s /bin/ash -D inframap
+
+USER 1000
+
+WORKDIR /home/inframap
+
+COPY --from=builder /app/inframap /home/inframap
+
+ENTRYPOINT ["inframap"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk -q --no-progress add git make \
 
 FROM alpine
 
-RUN apk -q --no-progress add graphviz ttf-dejavu\
+RUN apk -q --no-progress add graphviz ttf-dejavu \
         && addgroup -g 1000 inframap \
         && adduser -u 1000 -G inframap -s /bin/ash -D inframap
 
@@ -22,4 +22,4 @@ WORKDIR /home/inframap
 
 COPY --from=builder /app/inframap /home/inframap
 
-ENTRYPOINT ["inframap"]
+ENTRYPOINT ["./inframap"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 
 COPY . .
 
-RUN apk -q --no-progress add git make; \
+RUN apk -q --no-progress add git make graphviz ttf-dejavu; \
 	make build
 
 FROM alpine

--- a/README.md
+++ b/README.md
@@ -81,32 +81,40 @@ The most important subcommands are:
 Visualizing with [dot](https://graphviz.org/download/)
 
 ```shell
-$ inframap generate state.tfstate | dot -Tpng > graph.png
+inframap generate state.tfstate | dot -Tpng > graph.png
 ```
 
 or from the terminal itself with [graph-easy](https://github.com/ironcamel/Graph-Easy)
 
 ```shell
-$ inframap generate state.tfstate | graph-easy
+inframap generate state.tfstate | graph-easy
 ```
 
 or from HCL
 
 ```shell
-$ inframap generate config.tf | graph-easy
+inframap generate config.tf | graph-easy
 ```
 
 or HCL module
 
 ```shell
-$ inframap generate ./my-module/ | graph-easy
+inframap generate ./my-module/ | graph-easy
 ```
 
 using docker image (assuming that your Terraform files are in the working directory)
 
 ```shell
-$ docker run --rm -v ${PWD}:/opt cycloid/inframap generate /opt/terraform.tfstate
+docker run --rm -v ${PWD}:/opt cycloid/inframap generate /opt/terraform.tfstate
 ```
+
+or if you use docker and want to have the images generated already, the docker image has the `graphviz` lib installed:
+
+```shell
+docker run --rm -v ${PWD}:/opt --entrypoint "/bin/ash" inframap -c './inframap generate /opt/PATH_TO_HCL_STATE | dot -Tpng > /opt/graph.png'
+```
+
+and the generated image will be on `$PWD/graph.png`
 
 
 **Note:** InfraMap will guess the type of the input (HCL or TFState) by validating if it's a JSON and if it fails then we fallback


### PR DESCRIPTION
By not bundling grpahviz it cannot be used as a standalone  tool. What I was interested in is a docker image for a pre-commit hook. With this image, I can do the following pre-commit config:
```
      - id: terraform-inframap
        name: terraform-inframap
        language: docker_image
        entry: --entrypoint /bin/sh agalazis/inframap
        args: ['-c' , 'for file in $(find /src -name "*.tfstate" -o -name "*.tf") ; do output=${file%%.*};  /home/inframap/inframap generate $file | dot -Tpng  > "${output}.png" ;done;']
        pass_filenames: false
```
        
 Also, using root is not ideal.  So I configured a user for it.