### PR TITLE
Better support for "foreach" using sets or lists

### DIFF
--- a/generate/state.go
+++ b/generate/state.go
@@ -83,8 +83,11 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 			// The Instances is the representation of the
 			// 'count' on the Instance, could also be a 'for_each'
 			for id, iv := range rv.Instances {
-				if id != nil && id.String() != "[0]" {
-					continue
+				if id != nil {
+					matched, _ := regexp.MatchString("^\\[([0-9]*|\"(.*)\")\\]$", id.String())
+					if !matched {
+						continue
+					}
 				}
 				deps := make([]string, 0)
 				if len(iv.Current.Dependencies) != 0 {
@@ -100,6 +103,9 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 					for i, d := range deps {
 						if !strings.HasPrefix(d, "module.") {
 							deps[i] = prefixWithModule(m.Addr.String(), d)
+							if id != nil {
+								deps[i] = postfixWithId(deps[i], id.String())
+							}
 						}
 					}
 				}
@@ -140,6 +146,10 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 					Canonical: prefixWithModule(m.Addr.String(), rk),
 					TFID:      tfid.(string),
 					Resource:  *res,
+				}
+
+				if id != nil {
+					n.Canonical = postfixWithId(n.Canonical, id.String())
 				}
 
 				err = g.AddNode(n)
@@ -844,5 +854,20 @@ func prefixWithModule(moduleName, resource string) string {
 	if moduleName != "" {
 		resource = fmt.Sprintf("%s.%s", moduleName, resource)
 	}
+
+	return resource
+}
+
+func postfixWithId(resource string, id string) string {
+	matched, err := regexp.MatchString("^\\[\"(.*)\"\\]$", id)
+	if matched && err == nil {
+		resource = fmt.Sprintf("%s!%s", resource, id[2:len(id) - 2])
+	}
+
+	matched, err = regexp.MatchString("^\\[([0-9]*)]$", id)
+	if matched && err == nil {
+		resource = fmt.Sprintf("%s!%s", resource, id[1:len(id) - 1])
+	}
+
 	return resource
 }

--- a/provider/azurerm/graph.go
+++ b/provider/azurerm/graph.go
@@ -31,6 +31,7 @@ var (
 		"azurerm_lb":                                struct{}{},
 		"azurerm_linux_function_app":                struct{}{},
 		"azurerm_linux_virtual_machine":             struct{}{},
+		"azurerm_linux_web_app":                     struct{}{},
 		"azurerm_mariadb_database":                  struct{}{},
 		"azurerm_mariadb_server":                    struct{}{},
 		"azurerm_mssql_database":                    struct{}{},
@@ -59,8 +60,9 @@ var (
 		"azurerm_virtual_machine":                   struct{}{},
 		"azurerm_virtual_network_gateway":           struct{}{},
 		"azurerm_vpn_gateway":                       struct{}{},
-		"azurerm_windows_virtual_machine":           struct{}{},
 		"azurerm_windows_function_app":              struct{}{},
+		"azurerm_windows_virtual_machine":           struct{}{},
+		"azurerm_windows_web_app":                   struct{}{},
 		"azurerm_virtual_network":                   struct{}{},
 	}
 

--- a/provider/azurerm/graph.go
+++ b/provider/azurerm/graph.go
@@ -7,6 +7,7 @@ var (
 		"azurerm_app_service_environment":           struct{}{},
 		"azurerm_app_service_plan":                  struct{}{},
 		"azurerm_application_gateway":               struct{}{},
+		"azurerm_application_insights":              struct{}{},
 		"azurerm_bastion_host":                      struct{}{},
 		"azurerm_batch_account":                     struct{}{},
 		"azurerm_batch_application":                 struct{}{},
@@ -24,9 +25,11 @@ var (
 		"azurerm_frontdoor":                         struct{}{},
 		"azurerm_function_app":                      struct{}{},
 		"azurerm_image":                             struct{}{},
+		"azurerm_key_vault":                         struct{}{},
 		"azurerm_kubernetes_cluster":                struct{}{},
 		"azurerm_kubernetes_cluster_node_pool":      struct{}{},
 		"azurerm_lb":                                struct{}{},
+		"azurerm_linux_function_app":                struct{}{},
 		"azurerm_linux_virtual_machine":             struct{}{},
 		"azurerm_mariadb_database":                  struct{}{},
 		"azurerm_mariadb_server":                    struct{}{},
@@ -47,18 +50,23 @@ var (
 		"azurerm_private_endpoint":                  struct{}{},
 		"azurerm_public_ip":                         struct{}{},
 		"azurerm_redis_cache":                       struct{}{},
+		"azurerm_resource_group":                    struct{}{},
+		"azurerm_service_plan":                      struct{}{},
 		"azurerm_sql_database":                      struct{}{},
 		"azurerm_sql_server":                        struct{}{},
+		"azurerm_storage_account":                   struct{}{},
 		"azurerm_storage_container":                 struct{}{},
 		"azurerm_virtual_machine":                   struct{}{},
 		"azurerm_virtual_network_gateway":           struct{}{},
 		"azurerm_vpn_gateway":                       struct{}{},
 		"azurerm_windows_virtual_machine":           struct{}{},
+		"azurerm_windows_function_app":              struct{}{},
 		"azurerm_virtual_network":                   struct{}{},
 	}
 
 	// edgeTypes map of all the supported Edges
 	edgeTypes = map[string]struct{}{
 		"azurerm_virtual_network_peering": {},
+		"azurerm_key_vault_secret": {},
 	}
 )


### PR DESCRIPTION
When using "foreach" in your terraform a lot of nodes end up missing in the generated graph. I adapted the `state.go` generator to detect instances of resources either by their index or by their name (if using maps/sets). I post fix the name of a resource with ! and then either the index or name of the resource.

This PR also includes additional azure nodes, because it mostly contained network related things and is missing some common other nodes.

Example:
![dwh-insights-azurefunctions test terraform](https://github.com/cycloidio/inframap/assets/4518773/3bbee8c7-dd3c-4e4f-8a2e-feb071a8a3df)
