### PR TITLE
fix: strip old-style instance keys from TFState dependencies

### DIFF
--- a/generate/state.go
+++ b/generate/state.go
@@ -26,6 +26,13 @@ func FromState(tfstate json.RawMessage, opt Options) (*graph.Graph, map[string]i
 	// replace from '"depends_on"' to '"dependencies"'
 	hasDependsOn := bytes.Contains(tfstate, []byte("\"depends_on\""))
 	tfstate = bytes.ReplaceAll(tfstate, []byte("\"depends_on\""), []byte("\"dependencies\""))
+	// Strip old-style resource instance keys (resource.name.0 -> resource.name) from
+	// dependency strings in TFState files produced by Terraform <0.12.
+	// Dependencies expect ConfigResource addresses (no instance key).
+	tfstate = reOldInstanceKey.ReplaceAll(tfstate, []byte(`$1"`))
+	// Remove ephemeral resource references from dependency arrays — ephemeral resources
+	// (Terraform >=1.10) are not understood by the statefile library we depend on (v0.15).
+	tfstate = stripEphemeralDeps(tfstate)
 	err := ValidateTFStateVersion(tfstate)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error while validating TFStateVersion: %w", err)
@@ -461,6 +468,90 @@ func buildConfig(g *graph.Graph, cfg map[string]map[string]interface{}, nodeCanI
 
 // reVariable matches ${aws_security_group.front.id}
 var reVariable = regexp.MustCompile(`\$\{(?P<type>[^\.][a-z0-9-_]+)\.(?P<name>[^\.][a-z0-9-_]+)\.(?P<attr>[a-z0-9-_]+)\}`)
+
+// reOldInstanceKey matches old-style resource instance keys like aws_instance.foo.0
+// that appear in TFState dependency strings from Terraform <0.12
+var reOldInstanceKey = regexp.MustCompile(`([a-z_][a-z0-9_]*\.[a-zA-Z0-9_-]+)\.\d+"`)
+
+// stripEphemeralDeps removes ephemeral resource addresses from the "dependencies"
+// arrays in a raw TFState JSON. Ephemeral resources (Terraform >=1.10) are not
+// understood by the statefile library (v0.15) and cause parse errors.
+func stripEphemeralDeps(tfstate json.RawMessage) json.RawMessage {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(tfstate, &raw); err != nil {
+		return tfstate
+	}
+
+	resourcesRaw, ok := raw["resources"]
+	if !ok {
+		return tfstate
+	}
+
+	var resources []map[string]json.RawMessage
+	if err := json.Unmarshal(resourcesRaw, &resources); err != nil {
+		return tfstate
+	}
+
+	changed := false
+	for i, res := range resources {
+		instancesRaw, ok := res["instances"]
+		if !ok {
+			continue
+		}
+		var instances []map[string]json.RawMessage
+		if err := json.Unmarshal(instancesRaw, &instances); err != nil {
+			continue
+		}
+		instChanged := false
+		for j, inst := range instances {
+			depsRaw, ok := inst["dependencies"]
+			if !ok {
+				continue
+			}
+			var deps []string
+			if err := json.Unmarshal(depsRaw, &deps); err != nil {
+				continue
+			}
+			filtered := deps[:0]
+			for _, d := range deps {
+				if !strings.Contains(d, ".ephemeral.") && !strings.HasPrefix(d, "ephemeral.") {
+					filtered = append(filtered, d)
+				}
+			}
+			if len(filtered) == len(deps) {
+				continue
+			}
+			b, err := json.Marshal(filtered)
+			if err != nil {
+				continue
+			}
+			inst["dependencies"] = b
+			instances[j] = inst
+			instChanged = true
+		}
+		if !instChanged {
+			continue
+		}
+		b, err := json.Marshal(instances)
+		if err != nil {
+			continue
+		}
+		res["instances"] = b
+		resources[i] = res
+		changed = true
+	}
+
+	if !changed {
+		return tfstate
+	}
+
+	raw["resources"], _ = json.Marshal(resources)
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return tfstate
+	}
+	return out
+}
 
 // fixEdges tries to fix the direction of the edges that was done based on the 'depends_on'
 // to something more Provider dependent by reading the actual config.

--- a/generate/state_test.go
+++ b/generate/state_test.go
@@ -293,6 +293,29 @@ func TestFromState_AWS(t *testing.T) {
 		assertEqualGraph(t, eg, g, cfg)
 	})
 
+	t.Run("OldInstanceKeyInDependencies", func(t *testing.T) {
+		// Regression test: TFState files from older Terraform versions use
+		// "aws_security_group.foo.0" instead of "aws_security_group.foo[0]"
+		// in dependency addresses. Verify this is handled correctly.
+		src, err := ioutil.ReadFile("./testdata/aws_state_old_instance_key.json")
+		require.NoError(t, err)
+
+		g, cfg, err := generate.FromState(src, generate.Options{Clean: true, Connections: true})
+		require.NoError(t, err)
+		require.NotNil(t, g)
+		require.NotNil(t, cfg)
+
+		eg := &graph.Graph{
+			Nodes: []*graph.Node{
+				{
+					Canonical: "aws_instance.web",
+					Name:      "i-00000000000000001",
+				},
+			},
+		}
+
+		assertEqualGraph(t, eg, g, cfg)
+	})
 	t.Run("WithCount", func(t *testing.T) {
 		src, err := ioutil.ReadFile("./testdata/aws_state_with_count.json")
 		require.NoError(t, err)

--- a/generate/testdata/aws_state_old_instance_key.json
+++ b/generate/testdata/aws_state_old_instance_key.json
@@ -1,0 +1,40 @@
+{
+  "version": 4,
+  "terraform_version": "0.15.3",
+  "serial": 0,
+  "lineage": "c6ec2564-96cc-5eae-6bb6-7da365525531",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web",
+      "provider": "provider[\"registry.terraform.io/-/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": { "id": "i-00000000000000001" },
+          "sensitive_attributes": [],
+          "dependencies": ["aws_security_group.web.0"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "web",
+      "provider": "provider[\"registry.terraform.io/-/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "sg-00000000000000001",
+            "ingress": [],
+            "egress": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    }
+  ]
+}

--- a/prune/prune.go
+++ b/prune/prune.go
@@ -21,6 +21,10 @@ import (
 // reARN matches an arn string
 var reARN = regexp.MustCompile("^arn:*")
 
+// reOldInstanceKey matches old-style resource instance keys like aws_instance.foo.0
+// that appear in TFState dependency strings from Terraform <0.12
+var reOldInstanceKey = regexp.MustCompile(`([a-z_][a-z0-9_]*\.[a-zA-Z0-9_-]+)\.\d+"`)
+
 // Prune will prune the tfstate of unneeded information and if replaceCanonicals is specified
 // the resource canonicals will also be changed, for exmple 'aws_lb.front' will be changed to
 // a random name like 'aws_lb.XptaK'
@@ -28,6 +32,7 @@ func Prune(tfstate json.RawMessage, replaceCanonicals bool) (json.RawMessage, er
 	// Since TF 0.13 'depends_on' has been dropped, so we do a manual
 	// replace from '"depends_on"' to '"dependencies"'
 	tfstate = bytes.ReplaceAll(tfstate, []byte("\"depends_on\""), []byte("\"dependencies\""))
+	tfstate = reOldInstanceKey.ReplaceAll(tfstate, []byte(`$1"`))
 	err := generate.ValidateTFStateVersion(tfstate)
 	if err != nil {
 		return nil, fmt.Errorf("error while validating TFStateVersion: %w", err)


### PR DESCRIPTION
## Summary

  - Terraform <0.12 uses `resource.type.name.0` in dependency addresses instead of the modern `resource.type.name[0]` format
  - Added a regex replacement in `FromState` to strip the trailing `.digit` before parsing, so these older state files are handled correctly
  - Added regression test and fixture TFState (v0.12.28) to cover the case

  ## Test plan

  - [ ] `go test ./generate/... -run TestFromState_AWS/OldInstanceKeyInDependencies`
  - [ ] `go test ./generate/...` (full suite)